### PR TITLE
Add English translation of German title "Passwort für die Verschlüsselung"

### DIFF
--- a/Project2FA.Shared/Strings/en/Resources.resw
+++ b/Project2FA.Shared/Strings/en/Resources.resw
@@ -1080,7 +1080,7 @@ Please synchronize the time in the settings.</value>
     <value>A password must be assigned for the encryption of the data file. It is strongly recommended to store this password securely in a password manager.</value>
   </data>
   <data name="NewDatafilePasswordInfoTitle" xml:space="preserve">
-    <value>Password for the encryption of the data file</value>
+    <value>Password for encryption</value>
   </data>
   <data name="TutorialPageItemCopyCodeBTNDesc" xml:space="preserve">
     <value>The key is copied to the clipboard.</value>

--- a/Project2FA.Shared/Strings/en/Resources.resw
+++ b/Project2FA.Shared/Strings/en/Resources.resw
@@ -1080,7 +1080,7 @@ Please synchronize the time in the settings.</value>
     <value>A password must be assigned for the encryption of the data file. It is strongly recommended to store this password securely in a password manager.</value>
   </data>
   <data name="NewDatafilePasswordInfoTitle" xml:space="preserve">
-    <value>Passwort für die Verschlüsselung</value>
+    <value>Password for the encryption of the data file</value>
   </data>
   <data name="TutorialPageItemCopyCodeBTNDesc" xml:space="preserve">
     <value>The key is copied to the clipboard.</value>


### PR DESCRIPTION
This title shows up in German when using the app in English, so I've replaced the German text with an English translation instead.

(The addition of a linebreak at the end of the file was added automatically by GitHub's editor, but files ending with a linebreak is what's recommended by git anyway.)
